### PR TITLE
feat: enable click selection across patient workflow

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,8 @@ header, .stDeployButton { visibility: hidden; height: 0; }
 """
 st.markdown(CUSTOM_CSS, unsafe_allow_html=True)
 
+HIGHLIGHT_COLOR = "#fff3cd"  # highlight color for selected rows
+
 # ==========================
 # Helpers
 # ==========================
@@ -411,492 +413,6 @@ def render_dashboard():
         calendar(events, options={"initialView": "dayGridMonth"})
 
 
-def view_patients():
-    st.subheader("👤 Patients")
-    search = st.text_input("Recherche (nom, prénom, téléphone)")
-    df = list_patients(search)
-
-    with st.expander("➕ Ajouter un patient", expanded=False):
-        with st.form("form_add_patient", clear_on_submit=True):
-            c1, c2 = st.columns(2)
-            with c1:
-                nom = st.text_input("Nom *")
-                prenom = st.text_input("Prénom")
-                cin = st.text_input("CIN")
-                telephone = st.text_input("Téléphone")
-                email = st.text_input("Email")
-            with c2:
-                dtn = st.date_input("Date de naissance", format="DD/MM/YYYY")
-                adresse = st.text_area("Adresse")
-                notes = st.text_area("Notes")
-            submitted = st.form_submit_button("Enregistrer")
-            if submitted:
-                if not nom.strip():
-                    st.error("Le nom est obligatoire.")
-                else:
-                    run_exec(
-                        "INSERT INTO patients (nom, prenom, cin, date_naissance, telephone, email, adresse, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                        (
-                            nom.strip(),
-                            prenom.strip(),
-                            cin.strip(),
-                            to_db_date(dtn),
-                            telephone.strip(),
-                            email.strip(),
-                            adresse.strip(),
-                            notes.strip(),
-                        ),
-                    )
-                    clear_caches()
-                    st.success("Patient ajouté avec succès.")
-                    st_rerun()
-
-    st.markdown("### 📋 Liste des patients")
-    if df.empty:
-        st.info("Aucun patient trouvé.")
-    else:
-        st.dataframe(df[["id", "nom", "prenom", "cin", "telephone", "email"]], use_container_width=True, hide_index=True)
-
-    st.markdown("---")
-    st.markdown("### ✏️ Modifier / Supprimer")
-    if df.empty:
-        st.caption("Ajoutez d'abord un patient.")
-        return
-    id_list = df["id"].tolist()
-    sel_id = st.selectbox("Choisir un patient par ID", id_list)
-    row = df[df["id"] == sel_id].iloc[0]
-    with st.form("form_edit_patient"):
-        c1, c2 = st.columns(2)
-        with c1:
-            nom = st.text_input("Nom *", row["nom"])
-            prenom = st.text_input("Prénom", row["prenom"] or "")
-            cin = st.text_input("CIN", row["cin"] or "")
-            telephone = st.text_input("Téléphone", row["telephone"] or "")
-            email = st.text_input("Email", row["email"] or "")
-        with c2:
-            dtn = st.date_input("Date de naissance", value=to_ui_date(row["date_naissance"]) or date(1990,1,1), format="DD/MM/YYYY")
-            adresse = st.text_area("Adresse", row["adresse"] or "")
-            notes = st.text_area("Notes", row["notes"] or "")
-        c3, c4 = st.columns(2)
-        if c3.form_submit_button("💾 Mettre à jour"):
-            if not nom.strip():
-                st.error("Le nom est obligatoire.")
-            else:
-                run_exec(
-                "UPDATE patients SET nom=?, prenom=?, cin=?, date_naissance=?, telephone=?, email=?, adresse=?, notes=? WHERE id=?",
-                    (nom.strip(), prenom.strip(), cin.strip(), to_db_date(dtn), telephone.strip(), email.strip(), adresse.strip(), notes.strip(), sel_id),
-                )
-                clear_caches()
-                st.success("Patient mis à jour.")
-                st_rerun()
-        if c4.form_submit_button("🗑️ Supprimer", help="Supprime également les traitements et séances associés"):
-            run_exec("DELETE FROM patients WHERE id=?", (sel_id,))
-            clear_caches()
-            st.success("Patient supprimé.")
-            st_rerun()
-
-    # ============================
-    # Traitements du patient
-    # ============================
-    st.markdown("---")
-    st.markdown("### 📝 Traitements du patient")
-    pt_df = list_traitements(patient_id=sel_id)
-
-    with st.expander("➕ Ajouter un traitement", expanded=False):
-        with st.form("form_add_traitement_for_patient", clear_on_submit=True):
-            diagnostic = st.text_input("Diagnostic / Motif")
-            tpec = st.text_input("Type de prise en charge", placeholder="Ex: Lombalgie, Rééducation post-op, etc.")
-            date_debut = st.date_input("Date de début", format="DD/MM/YYYY")
-            nb_prev = st.number_input("Nombre de séances prévues", min_value=1, max_value=100, value=10)
-            tarif = st.number_input("Tarif par séance (MAD)", min_value=0.0, step=10.0, value=0.0)
-            notes = st.text_area("Notes")
-            submitted = st.form_submit_button("Enregistrer")
-            if submitted:
-                run_exec(
-                    "INSERT INTO traitements (patient_id, diagnostic, type_prise_en_charge, date_debut, nb_seances_prevues, tarif_par_seance, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        sel_id,
-                        diagnostic.strip(),
-                        tpec.strip(),
-                        to_db_date(date_debut),
-                        int(nb_prev),
-                        float(tarif),
-                        notes.strip(),
-                    ),
-                )
-                clear_caches()
-                st.success("Traitement ajouté.")
-                st_rerun()
-
-    if pt_df.empty:
-        st.info("Aucun traitement pour ce patient.")
-        return
-
-    st.dataframe(
-        pt_df[["id", "diagnostic", "type_prise_en_charge", "date_debut", "statut"]],
-        use_container_width=True,
-        hide_index=True,
-    )
-
-    st.markdown("### ✏️ Modifier / Clôturer un traitement")
-    tid = st.selectbox("Choisir un traitement", pt_df["id"].tolist())
-    tr = pt_df[pt_df["id"] == tid].iloc[0]
-    with st.form("form_edit_traitement_for_patient"):
-        diagnostic = st.text_input("Diagnostic / Motif", tr["diagnostic"] or "")
-        tpec = st.text_input("Type de prise en charge", tr["type_prise_en_charge"] or "")
-        date_debut = st.date_input("Date de début", to_ui_date(tr["date_debut"]) or date.today(), format="DD/MM/YYYY")
-        nb_prev = st.number_input("Nombre de séances prévues", 1, 100, int(tr["nb_seances_prevues"]))
-        tarif = st.number_input("Tarif par séance (MAD)", min_value=0.0, step=10.0, value=float(tr["tarif_par_seance"]))
-        notes = st.text_area("Notes", tr["notes"] or "")
-        statut = st.selectbox("Statut", ["En cours", "Terminé", "Archivé"], index=["En cours", "Terminé", "Archivé"].index(tr["statut"]))
-        c1, c2, c3 = st.columns(3)
-        if c1.form_submit_button("💾 Mettre à jour"):
-            run_exec(
-                "UPDATE traitements SET diagnostic=?, type_prise_en_charge=?, date_debut=?, nb_seances_prevues=?, tarif_par_seance=?, notes=?, statut=? WHERE id=?",
-                (
-                    diagnostic.strip(),
-                    tpec.strip(),
-                    to_db_date(date_debut),
-                    int(nb_prev),
-                    float(tarif),
-                    notes.strip(),
-                    statut,
-                    tid,
-                ),
-            )
-            clear_caches()
-            st.success("Traitement mis à jour.")
-            st_rerun()
-        if c2.form_submit_button("🗑️ Supprimer", help="Supprime les séances associées"):
-            run_exec("DELETE FROM traitements WHERE id=?", (tid,))
-            clear_caches()
-            st.success("Traitement supprimé.")
-            st_rerun()
-        if c3.form_submit_button("✅ Clôturer (Terminé)"):
-            run_exec("UPDATE traitements SET statut='Terminé' WHERE id=?", (tid,))
-            clear_caches()
-            st.success("Traitement clôturé.")
-            st_rerun()
-
-    # ============================
-    # Séances du traitement
-    # ============================
-    st.markdown("---")
-    st.markdown("### 🗓️ Séances du traitement")
-    s_df = list_seances(traitement_id=tid)
-
-    with st.expander("➕ Planifier une séance", expanded=False):
-        with st.form("form_add_seance_for_patient", clear_on_submit=True):
-            d = st.date_input("Date *", format="DD/MM/YYYY")
-            duree = st.number_input("Durée (minutes)", min_value=15, max_value=240, value=45)
-            douleur_avant = st.slider("Douleur avant (0-10)", 0, 10, 5)
-            notes = st.text_area("Notes")
-            submitted = st.form_submit_button("Enregistrer")
-            if submitted:
-                run_exec(
-                    "INSERT INTO seances (traitement_id, date, duree_minutes, douleur_avant, notes) VALUES (?, ?, ?, ?, ?)",
-                    (
-                        tid,
-                        to_db_date(d),
-                        int(duree),
-                        int(douleur_avant),
-                        notes.strip(),
-                    ),
-                )
-                clear_caches()
-                st.success("Séance planifiée.")
-                st_rerun()
-
-    if s_df.empty:
-        st.info("Aucune séance pour ce traitement.")
-        return
-
-    s_df = s_df.sort_values("date")
-    st.dataframe(
-        s_df[["id", "date", "duree_minutes", "effectuee", "payee", "douleur_avant", "douleur_apres", "notes"]],
-        use_container_width=True,
-        hide_index=True,
-    )
-
-    st.markdown("### ✏️ Modifier une séance")
-    sid = st.selectbox("Choisir une séance (ID)", s_df["id"].tolist())
-    row = s_df[s_df["id"] == sid].iloc[0]
-    with st.form("form_edit_seance_for_patient"):
-        d = st.date_input("Date", to_ui_date(row["date"]) or date.today(), format="DD/MM/YYYY")
-        duree = st.number_input("Durée (minutes)", 15, 240, int(row["duree_minutes"]))
-        effectuee = st.checkbox("Effectuée", value=bool(row["effectuee"]))
-        payee = st.checkbox("Payée", value=bool(row["payee"]))
-        douleur_avant = st.slider("Douleur avant (0-10)", 0, 10, int(row["douleur_avant"]) if row["douleur_avant"] is not None else 5)
-        douleur_apres = st.slider("Douleur après (0-10)", 0, 10, int(row["douleur_apres"]) if row["douleur_apres"] is not None else 3)
-        notes = st.text_area("Notes", row["notes"] or "")
-        c1, c2 = st.columns(2)
-        if c1.form_submit_button("💾 Mettre à jour"):
-            run_exec(
-                "UPDATE seances SET date=?, duree_minutes=?, effectuee=?, payee=?, douleur_avant=?, douleur_apres=?, notes=? WHERE id=?",
-                (
-                    to_db_date(d),
-                    int(duree),
-                    int(effectuee),
-                    int(payee),
-                    int(douleur_avant),
-                    int(douleur_apres),
-                    notes.strip(),
-                    sid,
-                ),
-            )
-            clear_caches()
-            st.success("Séance mise à jour.")
-            st_rerun()
-        if c2.form_submit_button("🗑️ Supprimer"):
-            run_exec("DELETE FROM seances WHERE id=?", (sid,))
-            clear_caches()
-            st.success("Séance supprimée.")
-            st_rerun()
-
-
-def view_traitements():
-    st.subheader("📝 Traitements")
-    patients_df = list_patients()
-    if patients_df.empty:
-        st.info("Ajoutez d'abord un patient pour créer un traitement.")
-        return
-
-    with st.expander("➕ Ajouter un traitement", expanded=False):
-        with st.form("form_add_traitement", clear_on_submit=True):
-            pmap = {f"{r['nom']} {r['prenom']} (#{r['id']})": int(r["id"]) for _, r in patients_df.iterrows()}
-            patient_label = st.selectbox("Patient *", list(pmap.keys()))
-            diagnostic = st.text_input("Diagnostic / Motif")
-            tpec = st.text_input("Type de prise en charge", placeholder="Ex: Lombalgie, Rééducation post-op, etc.")
-            date_debut = st.date_input("Date de début", format="DD/MM/YYYY")
-            nb_prev = st.number_input("Nombre de séances prévues", min_value=1, max_value=100, value=10)
-            tarif = st.number_input("Tarif par séance (MAD)", min_value=0.0, step=10.0, value=0.0)
-            notes = st.text_area("Notes")
-            submitted = st.form_submit_button("Enregistrer")
-            if submitted:
-                run_exec(
-                    "INSERT INTO traitements (patient_id, diagnostic, type_prise_en_charge, date_debut, nb_seances_prevues, tarif_par_seance, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        pmap[patient_label],
-                        diagnostic.strip(),
-                        tpec.strip(),
-                        to_db_date(date_debut),
-                        int(nb_prev),
-                        float(tarif),
-                        notes.strip(),
-                    ),
-                )
-                clear_caches()
-                st.success("Traitement ajouté.")
-                st_rerun()
-
-    st.markdown("### 📋 Liste des traitements")
-    statut = st.selectbox("Filtrer par statut", ["Tous", "En cours", "Terminé", "Archivé"], index=1)
-    statut_filter = None if statut == "Tous" else statut
-    t_df = list_traitements(statut=statut_filter)
-    s_df = list_seances()
-    t_df = progression_traitement(t_df, s_df)
-
-    if t_df.empty:
-        st.info("Aucun traitement.")
-    else:
-        # enrichir avec nom/prénom patient
-        p_df = list_patients()
-        t_df = t_df.merge(p_df[["id", "nom", "prenom"]], left_on="patient_id", right_on="id", suffixes=("", "_p"))
-        t_df["progress_pct"] = (t_df["progress"] * 100).round(0).astype(int)
-        display = t_df[[
-            "id", "nom", "prenom", "diagnostic", "type_prise_en_charge", "date_debut",
-            "nb_seances_prevues", "seances_effectuees", "tarif_par_seance", "montant_du", "statut"
-        ]].rename(columns={
-            "id": "ID",
-            "nom": "Nom",
-            "prenom": "Prénom",
-            "diagnostic": "Diagnostic",
-            "type_prise_en_charge": "Prise en charge",
-            "date_debut": "Début",
-            "nb_seances_prevues": "Séances prévues",
-            "seances_effectuees": "Séances faites",
-            "tarif_par_seance": "Tarif (MAD)",
-            "montant_du": "Reste dû (MAD)",
-            "statut": "Statut"
-        })
-        st.dataframe(display, use_container_width=True, hide_index=True)
-
-    st.markdown("---")
-    st.markdown("### ✏️ Modifier / Clôturer")
-    if t_df.empty:
-        st.caption("Ajoutez d'abord un traitement.")
-        return
-
-    tid = st.selectbox("Choisir un traitement par ID", t_df["id"].tolist())
-    tr = t_df[t_df["id"] == tid].iloc[0]
-
-    with st.form("form_edit_traitement"):
-        diagnostic = st.text_input("Diagnostic / Motif", tr["diagnostic"] or "")
-        tpec = st.text_input("Type de prise en charge", tr["type_prise_en_charge"] or "")
-        date_debut = st.date_input("Date de début", to_ui_date(tr["date_debut"]) or date.today(), format="DD/MM/YYYY")
-        nb_prev = st.number_input("Nombre de séances prévues", 1, 100, int(tr["nb_seances_prevues"]))
-        tarif = st.number_input("Tarif par séance (MAD)", min_value=0.0, step=10.0, value=float(tr["tarif_par_seance"]))
-        notes = st.text_area("Notes", tr["notes"] or "")
-        statut = st.selectbox("Statut", ["En cours", "Terminé", "Archivé"], index=["En cours", "Terminé", "Archivé"].index(tr["statut"]))
-        c1, c2, c3 = st.columns(3)
-        if c1.form_submit_button("💾 Mettre à jour"):
-            run_exec(
-                "UPDATE traitements SET diagnostic=?, type_prise_en_charge=?, date_debut=?, nb_seances_prevues=?, tarif_par_seance=?, notes=?, statut=? WHERE id=?",
-                (diagnostic.strip(), tpec.strip(), to_db_date(date_debut), int(nb_prev), float(tarif), notes.strip(), statut, tid),
-            )
-            clear_caches()
-            st.success("Traitement mis à jour.")
-            st_rerun()
-        if c2.form_submit_button("🗑️ Supprimer", help="Supprime les séances associées"):
-            run_exec("DELETE FROM traitements WHERE id=?", (tid,))
-            clear_caches()
-            st.success("Traitement supprimé.")
-            st_rerun()
-        if c3.form_submit_button("✅ Clôturer (Terminé)"):
-            run_exec("UPDATE traitements SET statut='Terminé' WHERE id=?", (tid,))
-            clear_caches()
-            st.success("Traitement clôturé.")
-            st_rerun()
-
-
-def view_seances():
-    st.subheader("🗓️ Séances")
-    t_df = list_traitements(statut="En cours")
-    if t_df.empty:
-        st.info("Aucun traitement en cours. Créez d'abord un traitement.")
-        return
-
-    # Mapping affichage -> id
-    patients_df = list_patients()
-    t_df = t_df.merge(patients_df[["id", "nom", "prenom"]], left_on="patient_id", right_on="id", suffixes=("", "_p"))
-    t_df["label"] = t_df.apply(lambda r: f"{r['nom']} {r['prenom']} · {r['type_prise_en_charge'] or r['diagnostic'] or 'Traitement'} (#{r['id']})", axis=1)
-    tmap = {r["label"]: int(r["id"]) for _, r in t_df.iterrows()}
-
-    with st.expander("➕ Planifier une séance", expanded=False):
-        with st.form("form_add_seance", clear_on_submit=True):
-            label = st.selectbox("Traitement *", list(tmap.keys()))
-            d = st.date_input("Date *", format="DD/MM/YYYY")
-            duree = st.number_input("Durée (minutes)", min_value=15, max_value=240, value=45)
-            douleur_avant = st.slider("Douleur avant (0-10)", 0, 10, 5)
-            notes = st.text_area("Notes")
-            submitted = st.form_submit_button("Enregistrer")
-            if submitted:
-                run_exec(
-                    "INSERT INTO seances (traitement_id, date, duree_minutes, douleur_avant, notes) VALUES (?, ?, ?, ?, ?)",
-                    (
-                        tmap[label],
-                        to_db_date(d),
-                        int(duree),
-                        int(douleur_avant),
-                        notes.strip(),
-                    ),
-                )
-                clear_caches()
-                st.success("Séance planifiée.")
-                st_rerun()
-
-    st.markdown("### 🔎 Filtrer")
-    c1, c2, c3 = st.columns(3)
-    with c1:
-        label = st.selectbox("Traitement", ["Tous"] + list(tmap.keys()))
-        tid = None if label == "Tous" else tmap[label]
-    with c2:
-        dmin = st.date_input("Du", value=date.today() - timedelta(days=30), format="DD/MM/YYYY")
-    with c3:
-        dmax = st.date_input("Au", value=date.today() + timedelta(days=30), format="DD/MM/YYYY")
-
-    s_df = list_seances(traitement_id=tid, date_min=to_db_date(dmin), date_max=to_db_date(dmax))
-    if s_df.empty:
-        st.info("Aucune séance trouvée pour ce filtre.")
-    else:
-        s_df = s_df.sort_values("date")
-        # Ajout infos patient
-        t_all = list_traitements()
-        p_all = list_patients()
-        merged = s_df.merge(t_all[["id", "patient_id", "tarif_par_seance"]], left_on="traitement_id", right_on="id", suffixes=("", "_t")).merge(
-            p_all[["id", "nom", "prenom", "telephone"]], left_on="patient_id", right_on="id", suffixes=("", "_p")
-        )
-        merged = merged.rename(columns={
-            "date": "Date",
-            "nom": "Nom",
-            "prenom": "Prénom",
-            "telephone": "Téléphone",
-            "duree_minutes": "Durée (min)",
-            "effectuee": "Effectuée",
-            "payee": "Payée",
-            "notes": "Notes",
-            "tarif_par_seance": "Tarif (MAD)",
-        })
-        st.dataframe(
-            merged[["Date", "Nom", "Prénom", "Téléphone", "Durée (min)", "Effectuée", "Payée", "Tarif (MAD)", "douleur_avant", "douleur_apres", "Notes"]],
-            use_container_width=True,
-            hide_index=True,
-        )
-
-    st.markdown("---")
-    st.markdown("### ✏️ Gérer une séance")
-    if s_df.empty:
-        st.caption("Planifiez d'abord une séance.")
-        return
-
-    sid = st.selectbox("Choisir une séance (ID)", s_df["id"].tolist())
-    row = s_df[s_df["id"] == sid].iloc[0]
-    with st.form("form_edit_seance"):
-        d = st.date_input("Date", to_ui_date(row["date"]) or date.today(), format="DD/MM/YYYY")
-        duree = st.number_input("Durée (minutes)", 15, 240, int(row["duree_minutes"]))
-        effectuee = st.checkbox("Effectuée", value=bool(row["effectuee"]))
-        payee = st.checkbox("Payée", value=bool(row["payee"]))
-        douleur_avant = st.slider("Douleur avant (0-10)", 0, 10, int(row["douleur_avant"]) if row["douleur_avant"] is not None else 5)
-        douleur_apres = st.slider("Douleur après (0-10)", 0, 10, int(row["douleur_apres"]) if row["douleur_apres"] is not None else 3)
-        notes = st.text_area("Notes", row["notes"] or "")
-        c1, c2 = st.columns(2)
-        if c1.form_submit_button("💾 Mettre à jour"):
-            run_exec(
-                "UPDATE seances SET date=?, duree_minutes=?, effectuee=?, payee=?, douleur_avant=?, douleur_apres=?, notes=? WHERE id=?",
-                (to_db_date(d), int(duree), int(effectuee), int(payee), int(douleur_avant), int(douleur_apres), notes.strip(), sid),
-            )
-            clear_caches()
-            st.success("Séance mise à jour.")
-            st_rerun()
-        if c2.form_submit_button("🗑️ Supprimer"):
-            run_exec("DELETE FROM seances WHERE id=?", (sid,))
-            clear_caches()
-            st.success("Séance supprimée.")
-            st_rerun()
-
-
-def view_exports():
-    st.subheader("📤 Exports & Rapports")
-    st.caption("Téléchargez des extractions CSV simples.")
-
-    p_df = list_patients()
-    t_df = list_traitements()
-    s_df = list_seances()
-
-    c1, c2, c3 = st.columns(3)
-    with c1:
-        st.write("Patients")
-        csv = p_df.to_csv(index=False).encode("utf-8")
-        st.download_button("⬇️ Export CSV", data=csv, file_name="patients.csv", mime="text/csv")
-    with c2:
-        st.write("Traitements")
-        csv = t_df.to_csv(index=False).encode("utf-8")
-        st.download_button("⬇️ Export CSV", data=csv, file_name="traitements.csv", mime="text/csv")
-    with c3:
-        st.write("Séances")
-        csv = s_df.to_csv(index=False).encode("utf-8")
-        st.download_button("⬇️ Export CSV", data=csv, file_name="seances.csv", mime="text/csv")
-
-    st.markdown("---")
-    st.markdown("### 📈 Indicateurs simples")
-    if s_df.empty:
-        st.info("Pas de données de séances.")
-    else:
-        total_faites = int(s_df["effectuee"].sum())
-        total_payees = int(s_df["payee"].sum())
-        st.write(f"Séances effectuées : **{total_faites}** · Séances payées : **{total_payees}**")
-    
-
 # ==========================
 # Single hierarchical view
 # ==========================
@@ -906,6 +422,7 @@ def _go_to(level: str, patient_id: int | None = None, traitement_id: int | None 
     st.session_state["level"] = level
     st.session_state["current_patient_id"] = patient_id
     st.session_state["current_traitement_id"] = traitement_id
+    st.session_state["current_seance_id"] = None
     st_rerun()
 
 
@@ -916,8 +433,31 @@ def render_patients():
     search = st.text_input("Recherche (nom, prénom, téléphone)")
     df = list_patients(search)
     display_df = df[["nom", "prenom", "telephone", "email"]].copy()
-    display_df.index = range(1, len(display_df) + 1)
-    st.dataframe(display_df, use_container_width=True)
+
+    sel = (
+        st.session_state.get("patients_table", {})
+        .get("selection", {})
+        .get("rows", [])
+    )
+    if sel:
+        st.session_state["current_patient_id"] = int(df.iloc[sel[0]]["id"])
+
+    def _patient_highlight(row: pd.Series) -> list[str]:
+        pid = st.session_state.get("current_patient_id")
+        if pid is None:
+            return [""] * len(row)
+        idx = df.index[df["id"] == pid]
+        if not idx.empty and row.name == idx[0]:
+            return [f"background-color: {HIGHLIGHT_COLOR}"] * len(row)
+        return [""] * len(row)
+
+    styled_df = display_df.style.apply(_patient_highlight, axis=1)
+    st.data_editor(
+        styled_df,
+        hide_index=True,
+        use_container_width=True,
+        key="patients_table",
+    )
 
     with st.expander("➕ Ajouter un patient", expanded=False):
         with st.form("form_add_patient_simple", clear_on_submit=True):
@@ -948,12 +488,11 @@ def render_patients():
         st.info("Aucun patient trouvé.")
         return
 
-    patient_opts = {
-        f"{r['nom']} {r['prenom']} - {r['telephone']} - {r['cin']}": int(r["id"])
-        for _, r in df.iterrows()
-    }
-    selected_label = st.selectbox("Choisir un patient", list(patient_opts.keys()))
-    pid = patient_opts[selected_label]
+    pid = st.session_state.get("current_patient_id")
+    if pid is None:
+        st.caption("Aucun patient sélectionné.")
+        return
+
     row = df[df["id"] == pid].iloc[0]
     st.caption(
         f"Patient sélectionné : {row['nom']} {row['prenom']} - {row['telephone']} - {row['cin']}"
@@ -1011,8 +550,31 @@ def render_traitements():
 
     t_df = list_traitements(patient_id=pid)
     display_t = t_df[["diagnostic", "type_prise_en_charge", "date_debut", "statut"]].copy()
-    display_t.index = range(1, len(display_t) + 1)
-    st.dataframe(display_t, use_container_width=True)
+
+    sel = (
+        st.session_state.get("traitements_table", {})
+        .get("selection", {})
+        .get("rows", [])
+    )
+    if sel:
+        st.session_state["current_traitement_id"] = int(t_df.iloc[sel[0]]["id"])
+
+    def _traitement_highlight(row: pd.Series) -> list[str]:
+        tid = st.session_state.get("current_traitement_id")
+        if tid is None:
+            return [""] * len(row)
+        idx = t_df.index[t_df["id"] == tid]
+        if not idx.empty and row.name == idx[0]:
+            return [f"background-color: {HIGHLIGHT_COLOR}"] * len(row)
+        return [""] * len(row)
+
+    styled_t = display_t.style.apply(_traitement_highlight, axis=1)
+    st.data_editor(
+        styled_t,
+        hide_index=True,
+        use_container_width=True,
+        key="traitements_table",
+    )
 
     with st.expander("➕ Ajouter un traitement", expanded=False):
         with st.form("form_add_traitement_simple", clear_on_submit=True):
@@ -1035,12 +597,11 @@ def render_traitements():
         st.info("Aucun traitement pour ce patient.")
         return
 
-    t_opts = {
-        f"{r['diagnostic']} - {r['date_debut']}": int(r["id"])
-        for _, r in t_df.iterrows()
-    }
-    t_label = st.selectbox("Choisir un traitement", list(t_opts.keys()))
-    tid = t_opts[t_label]
+    tid = st.session_state.get("current_traitement_id")
+    if tid is None:
+        st.caption("Aucun traitement sélectionné.")
+        return
+
     tr = t_df[t_df["id"] == tid].iloc[0]
     st.caption(
         f"Traitement sélectionné : {tr['diagnostic']} - {tr['date_debut']}"
@@ -1088,8 +649,31 @@ def render_seances():
     s_df = list_seances(traitement_id=tid)
     display_s = s_df[["date", "heure", "duree_minutes", "cout", "effectuee", "payee", "notes"]].copy()
     display_s = display_s.rename(columns={"notes": "Note"})
-    display_s.index = range(1, len(display_s) + 1)
-    st.dataframe(display_s, use_container_width=True)
+
+    sel = (
+        st.session_state.get("seances_table", {})
+        .get("selection", {})
+        .get("rows", [])
+    )
+    if sel:
+        st.session_state["current_seance_id"] = int(s_df.iloc[sel[0]]["id"])
+
+    def _seance_highlight(row: pd.Series) -> list[str]:
+        sid = st.session_state.get("current_seance_id")
+        if sid is None:
+            return [""] * len(row)
+        idx = s_df.index[s_df["id"] == sid]
+        if not idx.empty and row.name == idx[0]:
+            return [f"background-color: {HIGHLIGHT_COLOR}"] * len(row)
+        return [""] * len(row)
+
+    styled_s = display_s.style.apply(_seance_highlight, axis=1)
+    st.data_editor(
+        styled_s,
+        hide_index=True,
+        use_container_width=True,
+        key="seances_table",
+    )
 
     with st.expander("➕ Planifier une séance", expanded=False):
         with st.form("form_add_seance_simple", clear_on_submit=True):
@@ -1118,12 +702,11 @@ def render_seances():
         st.info("Aucune séance pour ce traitement.")
         return
 
-    s_opts = {
-        f"{r['date']} {r['heure'] or ''}": int(r["id"])
-        for _, r in s_df.iterrows()
-    }
-    s_label = st.selectbox("Choisir une séance", list(s_opts.keys()))
-    sid = s_opts[s_label]
+    sid = st.session_state.get("current_seance_id")
+    if sid is None:
+        st.caption("Aucune séance sélectionnée.")
+        return
+
     row = s_df[s_df["id"] == sid].iloc[0]
     st.caption(
         f"Séance sélectionnée : {row['date']} {row['heure'] or ''}"
@@ -1172,6 +755,7 @@ def view_manager():
         st.session_state["level"] = "dashboard"
         st.session_state["current_patient_id"] = None
         st.session_state["current_traitement_id"] = None
+        st.session_state["current_seance_id"] = None
     level = st.session_state.get("level", "dashboard")
     if level == "dashboard":
         render_dashboard()


### PR DESCRIPTION
## Summary
- allow selecting patients directly from table with highlighted row
- use same row-click selection for treatments and séances
- centralize highlight color with `HIGHLIGHT_COLOR`
- update selection state before rendering so highlight and action panels refresh immediately

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b62fbb1c9c832db793be88b5983cb4