### PR TITLE
Select patient row directly in list

### DIFF
--- a/main.py
+++ b/main.py
@@ -590,16 +590,20 @@ def view_patients():
             d = st.date_input("Date *", format="DD/MM/YYYY")
             duree = st.number_input("Durée (minutes)", min_value=15, max_value=240, value=45)
             douleur_avant = st.slider("Douleur avant (0-10)", 0, 10, 5)
+            effectuee = st.checkbox("Effectuée")
+            payee = st.checkbox("Payée")
             notes = st.text_area("Notes")
             submitted = st.form_submit_button("Enregistrer")
             if submitted:
                 run_exec(
-                    "INSERT INTO seances (traitement_id, date, duree_minutes, douleur_avant, notes) VALUES (?, ?, ?, ?, ?)",
+                    "INSERT INTO seances (traitement_id, date, duree_minutes, douleur_avant, effectuee, payee, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         tid,
                         to_db_date(d),
                         int(duree),
                         int(douleur_avant),
+                        int(effectuee),
+                        int(payee),
                         notes.strip(),
                     ),
                 )
@@ -792,16 +796,20 @@ def view_seances():
             d = st.date_input("Date *", format="DD/MM/YYYY")
             duree = st.number_input("Durée (minutes)", min_value=15, max_value=240, value=45)
             douleur_avant = st.slider("Douleur avant (0-10)", 0, 10, 5)
+            effectuee = st.checkbox("Effectuée")
+            payee = st.checkbox("Payée")
             notes = st.text_area("Notes")
             submitted = st.form_submit_button("Enregistrer")
             if submitted:
                 run_exec(
-                    "INSERT INTO seances (traitement_id, date, duree_minutes, douleur_avant, notes) VALUES (?, ?, ?, ?, ?)",
+                    "INSERT INTO seances (traitement_id, date, duree_minutes, douleur_avant, effectuee, payee, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         tmap[label],
                         to_db_date(d),
                         int(duree),
                         int(douleur_avant),
+                        int(effectuee),
+                        int(payee),
                         notes.strip(),
                     ),
                 )
@@ -1173,16 +1181,20 @@ def render_seances():
             h = st.time_input("Heure", value=time(10, 0), step=timedelta(minutes=15))
             duree = st.number_input("Durée (minutes)", min_value=15, max_value=240, value=45)
             cout = st.number_input("Coût (MAD)", min_value=0.0, step=10.0, value=float(tr["tarif_par_seance"]))
+            effectuee = st.checkbox("Effectuée")
+            payee = st.checkbox("Payée")
             notes = st.text_area("Note")
             if st.form_submit_button("Enregistrer"):
                 run_exec(
-                    "INSERT INTO seances (traitement_id, date, heure, duree_minutes, cout, notes) VALUES (?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO seances (traitement_id, date, heure, duree_minutes, cout, effectuee, payee, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         tid,
                         to_db_date(d),
                         to_db_time(h),
                         int(duree),
                         float(cout),
+                        int(effectuee),
+                        int(payee),
                         notes.strip(),
                     ),
                 )

--- a/main.py
+++ b/main.py
@@ -612,8 +612,22 @@ def view_patients():
         return
 
     s_df = s_df.sort_values("date")
+    table = s_df[
+        [
+            "id",
+            "date",
+            "duree_minutes",
+            "effectuee",
+            "payee",
+            "douleur_avant",
+            "douleur_apres",
+            "notes",
+        ]
+    ].copy()
+    table["Effectuée"] = table.pop("effectuee").astype(bool)
+    table["Payée"] = table.pop("payee").astype(bool)
     st.dataframe(
-        s_df[["id", "date", "duree_minutes", "effectuee", "payee", "douleur_avant", "douleur_apres", "notes"]],
+        table,
         use_container_width=True,
         hide_index=True,
     )
@@ -1123,8 +1137,20 @@ def render_seances():
         _go_to("traitements", patient_id=pid)
 
     s_df = list_seances(traitement_id=tid)
-    display_s = s_df[["date", "heure", "duree_minutes", "cout", "effectuee", "payee", "notes"]].copy()
-    display_s = display_s.rename(columns={"notes": "Note"})
+    display_s = s_df[
+        ["date", "heure", "duree_minutes", "cout", "effectuee", "payee", "notes"]
+    ].copy()
+    display_s["Effectuée"] = display_s.pop("effectuee").astype(bool)
+    display_s["Payée"] = display_s.pop("payee").astype(bool)
+    display_s = display_s.rename(
+        columns={
+            "date": "Date",
+            "heure": "Heure",
+            "duree_minutes": "Durée (min)",
+            "cout": "Coût (MAD)",
+            "notes": "Note",
+        }
+    )
     display_s.index = range(1, len(display_s) + 1)
     df_state = st.dataframe(
         display_s,
@@ -1144,7 +1170,7 @@ def render_seances():
     with st.expander("➕ Planifier une séance", expanded=False):
         with st.form("form_add_seance_simple", clear_on_submit=True):
             d = st.date_input("Date *", format="DD/MM/YYYY")
-            h = st.time_input("Heure", value=time(10, 0))
+            h = st.time_input("Heure", value=time(10, 0), step=timedelta(minutes=5))
             duree = st.number_input("Durée (minutes)", min_value=15, max_value=240, value=45)
             cout = st.number_input("Coût (MAD)", min_value=0.0, step=10.0, value=float(tr["tarif_par_seance"]))
             notes = st.text_area("Note")
@@ -1185,7 +1211,11 @@ def render_seances():
             else:
                 with st.form("form_edit_seance_simple"):
                     d = st.date_input("Date", to_ui_date(row["date"]) or date.today(), format="DD/MM/YYYY")
-                    h = st.time_input("Heure", to_ui_time(row["heure"]) or time(10, 0))
+                    h = st.time_input(
+                        "Heure",
+                        to_ui_time(row["heure"]) or time(10, 0),
+                        step=timedelta(minutes=5),
+                    )
                     duree = st.number_input("Durée (minutes)", 15, 240, int(row["duree_minutes"]))
                     cout = st.number_input(
                         "Coût (MAD)",

--- a/main.py
+++ b/main.py
@@ -1170,7 +1170,7 @@ def render_seances():
     with st.expander("➕ Planifier une séance", expanded=False):
         with st.form("form_add_seance_simple", clear_on_submit=True):
             d = st.date_input("Date *", format="DD/MM/YYYY")
-            h = st.time_input("Heure", value=time(10, 0), step=timedelta(minutes=5))
+            h = st.time_input("Heure", value=time(10, 0), step=timedelta(minutes=15))
             duree = st.number_input("Durée (minutes)", min_value=15, max_value=240, value=45)
             cout = st.number_input("Coût (MAD)", min_value=0.0, step=10.0, value=float(tr["tarif_par_seance"]))
             notes = st.text_area("Note")
@@ -1214,7 +1214,7 @@ def render_seances():
                     h = st.time_input(
                         "Heure",
                         to_ui_time(row["heure"]) or time(10, 0),
-                        step=timedelta(minutes=5),
+                        step=timedelta(minutes=15),
                     )
                     duree = st.number_input("Durée (minutes)", 15, 240, int(row["duree_minutes"]))
                     cout = st.number_input(

--- a/main.py
+++ b/main.py
@@ -919,29 +919,21 @@ def render_patients():
     display_df.index = range(1, len(display_df) + 1)
 
     # Use row selection instead of a separate dropdown
-    selected_pid = st.session_state.get("current_patient_id")
-    preselect: dict | None = None
-    if selected_pid is not None and not df[df["id"] == selected_pid].empty:
-        preselect = {"rows": [int(df.index[df["id"] == selected_pid][0])]}
-
-    st.dataframe(
+    df_state = st.dataframe(
         display_df,
         use_container_width=True,
         key="patients_table",
         on_select="rerun",
-        selection=preselect,
+        selection_mode="single-row",
     )
 
     # Update the current patient in session state when a row is clicked
-    selected_rows = (
-        st.session_state.get("patients_table", {})
-        .get("selection", {})
-        .get("rows", [])
-    )
-    if selected_rows:
+    if df_state.selection.rows:
         st.session_state["current_patient_id"] = int(
-            df.iloc[selected_rows[0]]["id"]
+            df.iloc[df_state.selection.rows[0]]["id"]
         )
+    else:
+        st.session_state["current_patient_id"] = None
 
     with st.expander("➕ Ajouter un patient", expanded=False):
         with st.form("form_add_patient_simple", clear_on_submit=True):
@@ -974,53 +966,54 @@ def render_patients():
     pid = st.session_state.get("current_patient_id")
     row = df[df["id"] == pid].iloc[0] if pid is not None and not df.empty and not df[df["id"] == pid].empty else None
 
-    st.caption(
-        f"Patient sélectionné : {row['nom']} {row['prenom']} - {row['telephone']} - {row['cin']}"
-        if row is not None
-        else "Patient sélectionné : Aucun"
-    )
+    with st.container(border=True):
+        st.caption(
+            f"Patient sélectionné : {row['nom']} {row['prenom']} - {row['telephone']} - {row['cin']}"
+            if row is not None
+            else "Patient sélectionné : Aucun",
+        )
 
-    with st.expander("✏️ Modifier / Supprimer", expanded=False):
-        if row is None:
-            st.info("Sélectionnez un patient pour modifier ou supprimer.")
-        else:
-            with st.form("form_edit_patient_simple"):
-                c1, c2 = st.columns(2)
-                with c1:
-                    nom = st.text_input("Nom *", row["nom"])
-                    prenom = st.text_input("Prénom", row["prenom"] or "")
-                    cin = st.text_input("CIN", row["cin"] or "")
-                    telephone = st.text_input("Téléphone", row["telephone"] or "")
-                    email = st.text_input("Email", row["email"] or "")
-                with c2:
-                    dtn = st.date_input(
-                        "Date de naissance",
-                        value=to_ui_date(row["date_naissance"]) or date(1990, 1, 1),
-                        min_value=date(1900, 1, 1),
-                        format="DD/MM/YYYY",
-                    )
-                    adresse = st.text_area("Adresse", row["adresse"] or "")
-                    notes = st.text_area("Notes", row["notes"] or "")
-                c3, c4 = st.columns(2)
-                if c3.form_submit_button("💾 Mettre à jour"):
-                    if not nom.strip():
-                        st.error("Le nom est obligatoire.")
-                    else:
-                        run_exec(
-                            "UPDATE patients SET nom=?, prenom=?, cin=?, date_naissance=?, telephone=?, email=?, adresse=?, notes=? WHERE id=?",
-                            (nom.strip(), prenom.strip(), cin.strip(), to_db_date(dtn), telephone.strip(), email.strip(), adresse.strip(), notes.strip(), pid),
+        with st.expander("✏️ Modifier / Supprimer", expanded=False):
+            if row is None:
+                st.info("Sélectionnez un patient pour modifier ou supprimer.")
+            else:
+                with st.form("form_edit_patient_simple"):
+                    c1, c2 = st.columns(2)
+                    with c1:
+                        nom = st.text_input("Nom *", row["nom"])
+                        prenom = st.text_input("Prénom", row["prenom"] or "")
+                        cin = st.text_input("CIN", row["cin"] or "")
+                        telephone = st.text_input("Téléphone", row["telephone"] or "")
+                        email = st.text_input("Email", row["email"] or "")
+                    with c2:
+                        dtn = st.date_input(
+                            "Date de naissance",
+                            value=to_ui_date(row["date_naissance"]) or date(1990, 1, 1),
+                            min_value=date(1900, 1, 1),
+                            format="DD/MM/YYYY",
                         )
+                        adresse = st.text_area("Adresse", row["adresse"] or "")
+                        notes = st.text_area("Notes", row["notes"] or "")
+                    c3, c4 = st.columns(2)
+                    if c3.form_submit_button("💾 Mettre à jour"):
+                        if not nom.strip():
+                            st.error("Le nom est obligatoire.")
+                        else:
+                            run_exec(
+                                "UPDATE patients SET nom=?, prenom=?, cin=?, date_naissance=?, telephone=?, email=?, adresse=?, notes=? WHERE id=?",
+                                (nom.strip(), prenom.strip(), cin.strip(), to_db_date(dtn), telephone.strip(), email.strip(), adresse.strip(), notes.strip(), pid),
+                            )
+                            clear_caches()
+                            st.success("Patient mis à jour.")
+                            st_rerun()
+                    if c4.form_submit_button("🗑️ Supprimer", help="Supprime également les traitements et séances associés"):
+                        run_exec("DELETE FROM patients WHERE id=?", (pid,))
                         clear_caches()
-                        st.success("Patient mis à jour.")
+                        st.success("Patient supprimé.")
                         st_rerun()
-                if c4.form_submit_button("🗑️ Supprimer", help="Supprime également les traitements et séances associés"):
-                    run_exec("DELETE FROM patients WHERE id=?", (pid,))
-                    clear_caches()
-                    st.success("Patient supprimé.")
-                    st_rerun()
 
-    if st.button("📋 Ouvrir les traitements du patient", disabled=row is None):
-        _go_to("traitements", patient_id=pid)
+        if st.button("📋 Ouvrir les traitements du patient", disabled=row is None):
+            _go_to("traitements", patient_id=pid)
 
 
 def render_traitements():


### PR DESCRIPTION
## Summary
- allow patient selection by clicking a highlighted row in the table
- keep selected patient area with edit/delete and treatment access visible

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b641ee42d8832db7e003af55e98eaf